### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: jzweifel/gatsby-cli-github-action/gatsby-cli-github-action
+        name: jerluc/gatsby-cli-github-action/gatsby-cli-github-action
         password: ${{ secrets.DOCKER_PASSWORD }}
         username: ${{ secrets.DOCKER_USERNAME }}
         registry: docker.pkg.github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 LABEL version="1.0.0"
 LABEL "repository"="http://github.com/jzweifel/gatsby-cli-github-action"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ jobs:
     name: Build Gatsby Site
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Build Gatsby Site
-      uses: jzweifel/gatsby-cli-github-action@master
-      with:
-        gatsby-arg: build
+      - uses: actions/checkout@master
+      - name: Build Gatsby Site
+        uses: jerluc/gatsby-cli-github-action@master
+        with:
+          gatsby-arg: build
 ```
 
 ```yml
@@ -27,13 +27,13 @@ jobs:
     name: Build Gatsby Site
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Build Gatsby Site
-      uses: jzweifel/gatsby-cli-github-action@master
-      env:
-        GATSBY_PROJECT_PATH: "./client"
-      with:
-        gatsby-arg: build
+      - uses: actions/checkout@master
+      - name: Build Gatsby Site
+        uses: jerluc/gatsby-cli-github-action@master
+        env:
+          GATSBY_PROJECT_PATH: "./client"
+        with:
+          gatsby-arg: build
 ```
 
 ### Inputs
@@ -44,7 +44,7 @@ jobs:
 
 ### Environment variables
 
-* `GATSBY_PROJECT_PATH` - **Optional**. Directory from which to execute the Gatsby CLI.
+- `GATSBY_PROJECT_PATH` - **Optional**. Directory from which to execute the Gatsby CLI.
 
 ## License
 

--- a/script/test
+++ b/script/test
@@ -6,5 +6,5 @@ set -e
 # Ensure we're always running from the project root
 cd "$(dirname "$0")/.."
 
-bats test/*.bats
-shellcheck *.sh
+bats "test/*.bats"
+shellcheck "*.sh"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore